### PR TITLE
build: allow refreshmod with external out directory

### DIFF
--- a/envsetup.sh
+++ b/envsetup.sh
@@ -1345,7 +1345,7 @@ function refreshmod() {
     mkdir -p $ANDROID_PRODUCT_OUT || return 1
 
     # Note, can't use absolute path because of the way make works.
-    m out/target/product/$(get_build_var TARGET_DEVICE)/module-info.json \
+    m $(get_build_var PRODUCT_OUT)/module-info.json \
         > $ANDROID_PRODUCT_OUT/module-info.json.build.log 2>&1
 }
 


### PR DESCRIPTION
Get a relative path to out by using $(get_build_var PRODUCT_OUT)
instead of hardcoding it to out/target/product/$TARGET_DEVICE.
That will correctly return the path to the out directory
when setting an external OUT_DIR_COMMON_BASE.

Change-Id: I8a990b710222bc72755c6b6b88fd0c9e80711e14