### PR TITLE
Bump Security String to 2020-11-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -250,7 +250,7 @@ ifndef PLATFORM_SECURITY_PATCH
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-      PLATFORM_SECURITY_PATCH := 2020-10-05
+      PLATFORM_SECURITY_PATCH := 2020-11-05
 endif
 .KATI_READONLY := PLATFORM_SECURITY_PATCH
 


### PR DESCRIPTION
Implemented:
============
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0409   A-156997193  EoP    High       8.0, 8.1, 9, 10
CVE-2020-0424   A-161362564  ID     High       9, 10, 11
CVE-2020-0437   A-162741784  DoS    High       8.0, 8.1, 9, 10, 11
CVE-2020-0438   A-161812320  EoP    High       11
                             EoP    Moderate   10
CVE-2020-0439   A-140256621  EoP    High       8.0, 8.1, 9, 10, 11
CVE-2020-0441   A-158304295  DoS    Critical   8.0, 8.1, 9, 10, 11
CVE-2020-0442   A-147358092  DoS    Critical   8.0, 8.1, 9, 10, 11
CVE-2020-0443   A-152410253  DoS    High       8.0, 8.1, 9, 10, 11
CVE-2020-0448   A-153995334  ID     High       8.0, 8.1, 9, 10, 11
CVE-2020-0449   A-162497143  RCE    Critical   8.0, 8.1, 9, 10, 11
CVE-2020-0450   A-157650336  ID     High       8.0, 8.1, 9, 10, 11
CVE-2020-0451   A-158762825  ID     High       10, 11
                             RCE    Critical   8.0, 8.1, 9
CVE-2020-0452   A-159625731  RCE    High       8.0, 8.1, 9, 10, 11
CVE-2020-12856  A-157038281  EoP    High       8.0, 8.1, 9, 10, 11

Previously Implemented:
=======================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0418   A-153879813  EoP    High       10

Not Implemented:
================
None

Not Applicable (platform source):
=================================
CVE:            References:  Type:  Severity:  Updated AOSP versions:
CVE-2020-0453   A-159060474  ID     High       8.0, 8.1, 9
CVE-2020-0454   A-161370134  ID     High       9

Change-Id: I7034e2e52168aaa77ed63dd24076b391bd34427c